### PR TITLE
Implement Error trait for Error struct (with the help of thiserror)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,11 +413,12 @@ checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bdt"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "comfy-table 6.2.0",
  "datafusion",
  "structopt",
+ "thiserror",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ comfy-table = "6.1.2"
 datafusion = { version = "33.0", features = ["avro"] }
 structopt = "0.3"
 tokio = "1.19"
+thiserror = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,30 +6,16 @@ pub mod convert;
 pub mod parquet;
 pub mod utils;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("{0}")]
     General(String),
-    DataFusion(DataFusionError),
-    Parquet(ParquetError),
-    IoError(std::io::Error),
-}
-
-impl From<DataFusionError> for Error {
-    fn from(e: DataFusionError) -> Self {
-        Self::DataFusion(e)
-    }
-}
-
-impl From<ParquetError> for Error {
-    fn from(e: ParquetError) -> Self {
-        Self::Parquet(e)
-    }
-}
-
-impl From<std::io::Error> for Error {
-    fn from(e: std::io::Error) -> Self {
-        Self::IoError(e)
-    }
+    #[error("Data Fusion error: {0}")]
+    DataFusion(#[from] DataFusionError),
+    #[error("Parquet error: {0}")]
+    Parquet(#[from] ParquetError),
+    #[error("I/O error: {0}")]
+    IoError(#[from] std::io::Error),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Hi, to use BDT as a lib in other programs, the Error struct should implements the Error trait.

It will be then easy to let some other crate such as `anyhow` or `eyre` handle error propagation and reporting.

This PR implements the Error trait on the struct using [`thiserror`](https://crates.io/crates/thiserror)

